### PR TITLE
Bump ember-cli-htmlbars to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-advanced-form",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "This addon is a set of components that can be used in forms.",
   "directories": {
     "doc": "doc",
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "1.0.1"
+    "ember-cli-htmlbars": "1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
at Function.Addon.lookup (/webapps/node_modules/ember-cli/lib/models/addon.js:1006:27)
```

with ember-cli 2.8.0